### PR TITLE
feat: add a single-instance check

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ ensures smooth operation even on servers with limited CPU resources.
 - Assigning worker processes to different cores to prevent resource contention
 - Optimizing multiprocess applications by controlling CPU resource allocation
 - Automatically moving existing processes from main cores to worker cores at startup to free up resources
+- Preventing multiple instances from running simultaneously to avoid conflicts
 - Especially helpful for servers without `GPUs`, where all processing loads (including browser processes that would
   normally use `GPU`) fall on the `CPU` and cores can easily become overloaded
 
@@ -99,9 +100,15 @@ poetry install
 
 When you start the tool, it is automatically:
 
-1. Identifies the available CPU cores and assigns them to main and worker processes
-2. Moves existing processes from main cores to worker cores to free up resources
-3. Begins monitoring and managing CPU affinity for all matching processes
+1. Checks if another instance is already running and prevents multiple instances
+2. Identifies the available CPU cores and assigns them to main and worker processes
+3. Moves existing processes from main cores to worker cores to free up resources
+4. Begins monitoring and managing CPU affinity for all matching processes
+
+If you attempt to start the tool when another instance is already running, you'll see an error message in a dialog box
+and the new
+instance will exit. This ensures that error messages are visible even when launching the application by double-clicking
+the executable file.
 
 ### Command Line
 

--- a/bas_set_cpu_affinity/cli.py
+++ b/bas_set_cpu_affinity/cli.py
@@ -11,7 +11,13 @@ import time
 import click
 import psutil
 
-from .core import move_processes_from_main_cores, parse_core_string, set_affinities, validate_cores
+from .core import (
+    check_single_instance,
+    move_processes_from_main_cores,
+    parse_core_string,
+    set_affinities,
+    validate_cores,
+)
 
 # Configure logging only if it hasn't been configured already
 # This allows the entry point script to set its own configuration
@@ -140,6 +146,9 @@ def manage_affinity(main_cores, interval, main_name, workers, verbose):
 
 def main():
     """Entry point for the CLI."""
+    # Check if another instance is already running
+    mutex = check_single_instance()
+
     # pylint: disable=no-value-for-parameter
     manage_affinity()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -882,6 +882,29 @@ pylint = ">2.0,<4.0"
 pylint-plugin-utils = "*"
 
 [[package]]
+name = "pywin32"
+version = "306"
+description = "Python for Window Extensions"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pywin32-306-cp310-cp310-win32.whl", hash = "sha256:06d3420a5155ba65f0b72f2699b5bacf3109f36acbe8923765c22938a69dfc8d"},
+    {file = "pywin32-306-cp310-cp310-win_amd64.whl", hash = "sha256:84f4471dbca1887ea3803d8848a1616429ac94a4a8d05f4bc9c5dcfd42ca99c8"},
+    {file = "pywin32-306-cp311-cp311-win32.whl", hash = "sha256:e65028133d15b64d2ed8f06dd9fbc268352478d4f9289e69c190ecd6818b6407"},
+    {file = "pywin32-306-cp311-cp311-win_amd64.whl", hash = "sha256:a7639f51c184c0272e93f244eb24dafca9b1855707d94c192d4a0b4c01e1100e"},
+    {file = "pywin32-306-cp311-cp311-win_arm64.whl", hash = "sha256:70dba0c913d19f942a2db25217d9a1b726c278f483a919f1abfed79c9cf64d3a"},
+    {file = "pywin32-306-cp312-cp312-win32.whl", hash = "sha256:383229d515657f4e3ed1343da8be101000562bf514591ff383ae940cad65458b"},
+    {file = "pywin32-306-cp312-cp312-win_amd64.whl", hash = "sha256:37257794c1ad39ee9be652da0462dc2e394c8159dfd913a8a4e8eb6fd346da0e"},
+    {file = "pywin32-306-cp312-cp312-win_arm64.whl", hash = "sha256:5821ec52f6d321aa59e2db7e0a35b997de60c201943557d108af9d4ae1ec7040"},
+    {file = "pywin32-306-cp37-cp37m-win32.whl", hash = "sha256:1c73ea9a0d2283d889001998059f5eaaba3b6238f767c9cf2833b13e6a685f65"},
+    {file = "pywin32-306-cp37-cp37m-win_amd64.whl", hash = "sha256:72c5f621542d7bdd4fdb716227be0dd3f8565c11b280be6315b06ace35487d36"},
+    {file = "pywin32-306-cp38-cp38-win32.whl", hash = "sha256:e4c092e2589b5cf0d365849e73e02c391c1349958c5ac3e9d5ccb9a28e017b3a"},
+    {file = "pywin32-306-cp38-cp38-win_amd64.whl", hash = "sha256:e8ac1ae3601bee6ca9f7cb4b5363bf1c0badb935ef243c4733ff9a393b1690c0"},
+    {file = "pywin32-306-cp39-cp39-win32.whl", hash = "sha256:e25fd5b485b55ac9c057f67d94bc203f3f6595078d1fb3b458c9c28b7153a802"},
+    {file = "pywin32-306-cp39-cp39-win_amd64.whl", hash = "sha256:39b61c15272833b5c329a2989999dcae836b1eed650252ab1b7bfbe1d59f30f4"},
+]
+
+[[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
@@ -1144,4 +1167,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "315fe9a7e1356cf913c071ae78b4b664ee6d0b89312475c56818e0b459af025a"
+content-hash = "6c327875f31115135b102b628b22ce7b684348287b4509716984923ad34eb9de"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ python = ">=3.10,<3.14"
 psutil = "7.0.0"
 pyinstaller = "6.13.0"
 click = "8.2.1"
+pywin32 = "306"
 
 [tool.poetry.scripts]
 set-cpu-affinity = "bas_set_cpu_affinity.cli:main"


### PR DESCRIPTION
This commit implements a feature that prevents multiple instances of the application from running simultaneously:

- Add check_single_instance function in core.py that:
- Creates a mutex with a unique name to track application instances
- Detects if another instance is already running
- Displays an error message in a dialog box visible when double-clicking the executable
- Exits gracefully if another instance is found

This feature ensures that users don't accidentally run multiple instances of the tool, which could lead to conflicts in CPU affinity management.